### PR TITLE
Refactor: Move detection patterns to JSON config

### DIFF
--- a/Service/CryptoShieldService/CryptoShieldService.vcxproj
+++ b/Service/CryptoShieldService/CryptoShieldService.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="Detection\SystemActivityMonitor.h" />
     <ClInclude Include="Detection\TraditionalEngine.h" />
     <ClInclude Include="MessageProcessor.h" />
+    <ClInclude Include="Utils\StringUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CommunicationManager.cpp" />
@@ -161,6 +162,7 @@
     <ClCompile Include="Detection\TraditionalEngine.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MessageProcessor.cpp" />
+    <ClCompile Include="Utils\StringUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Service/CryptoShieldService/CryptoShieldService.vcxproj
+++ b/Service/CryptoShieldService/CryptoShieldService.vcxproj
@@ -165,6 +165,10 @@
     <ClCompile Include="Utils\StringUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="detection_config.json">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Service/CryptoShieldService/CryptoShieldService.vcxproj.filters
+++ b/Service/CryptoShieldService/CryptoShieldService.vcxproj.filters
@@ -89,5 +89,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="detection_config.json" />
   </ItemGroup>
 </Project>

--- a/Service/CryptoShieldService/CryptoShieldService.vcxproj.filters
+++ b/Service/CryptoShieldService/CryptoShieldService.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="Detection\DetectionConfig.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Utils\StringUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CommunicationManager.cpp">
@@ -78,6 +81,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Detection\DetectionConfig.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\StringUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Service/CryptoShieldService/Detection/BehavioralDetector.h
+++ b/Service/CryptoShieldService/Detection/BehavioralDetector.h
@@ -103,20 +103,21 @@ namespace CryptoShield::Detection {
         /**
          * @brief Configuration for detection thresholds
          */
-        struct Configuration {
+        /*struct Configuration {
             size_t min_operations_threshold = 50;
             size_t min_directories_threshold = 3;
             size_t min_extensions_threshold = 2;
             double max_operations_per_second = 10.0;
             std::chrono::seconds window_duration{ 60 };
             double suspicion_score_threshold = 0.7;
-        };
+        };*/
 
         /**
          * @brief Constructor
          * @param config Detection configuration
          */
-        explicit MassFileModificationDetector(const Configuration& config = {});
+        //explicit MassFileModificationDetector(const Configuration& config = {});
+        explicit MassFileModificationDetector(const DetectionEngineConfig::BehavioralConfig& config);
 
         /**
          * @brief Destructor
@@ -139,7 +140,7 @@ namespace CryptoShield::Detection {
          * @brief Update configuration
          * @param config New configuration
          */
-        void UpdateConfiguration(const Configuration& config);
+        //void UpdateConfiguration(const Configuration& config);
 
         /**
          * @brief Get current window statistics
@@ -200,7 +201,7 @@ namespace CryptoShield::Detection {
         std::wstring ExtractExtension(const std::wstring& file_path) const;
 
     private:
-        Configuration config_;
+        DetectionEngineConfig::BehavioralConfig config_;
         OperationWindow current_window_;
         mutable std::mutex window_mutex_;
         std::chrono::steady_clock::time_point last_cleanup_;
@@ -213,7 +214,8 @@ namespace CryptoShield::Detection {
     class FileExtensionMonitor {
     public:
         // Modify constructor
-        explicit FileExtensionMonitor(const CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig& config);
+        //explicit FileExtensionMonitor(const CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig& config);
+        explicit FileExtensionMonitor(const DetectionEngineConfig::BehavioralConfig& config);
         /**
          * @brief Destructor
          */
@@ -259,6 +261,8 @@ namespace CryptoShield::Detection {
         void CleanupOldRecords(std::chrono::seconds max_age = std::chrono::seconds(3600));
 
     private:
+
+        
         /**
          * @brief Check if extension matches suspicious pattern
          * @param extension Extension to check
@@ -289,7 +293,7 @@ namespace CryptoShield::Detection {
         mutable std::mutex extensions_mutex_;
 
         // Add config member
-        CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig config_;
+        DetectionEngineConfig::BehavioralConfig config_;
     };
 
     /**
@@ -408,10 +412,10 @@ namespace CryptoShield::Detection {
          * @param min_extensions Minimum extensions affected
          * @param max_rate Maximum operations per second
          */
-        void ConfigureThresholds(size_t min_operations,
+        /*void ConfigureThresholds(size_t min_operations,
             size_t min_directories,
             size_t min_extensions,
-            double max_rate);
+            double max_rate);*/
 
         /**
          * @brief Get process behavior profile

--- a/Service/CryptoShieldService/Detection/BehavioralDetector.h
+++ b/Service/CryptoShieldService/Detection/BehavioralDetector.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../CommunicationManager.h"
+#include "DetectionConfig.h" // Added
 #include <windows.h>
 #include <vector>
 #include <queue>
@@ -211,11 +212,8 @@ namespace CryptoShield::Detection {
      */
     class FileExtensionMonitor {
     public:
-        /**
-         * @brief Constructor
-         */
-        FileExtensionMonitor();
-
+        // Modify constructor
+        explicit FileExtensionMonitor(const CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig& config);
         /**
          * @brief Destructor
          */
@@ -289,6 +287,9 @@ namespace CryptoShield::Detection {
         // Original extension tracking
         std::unordered_map<std::wstring, std::wstring> original_extensions_;
         mutable std::mutex extensions_mutex_;
+
+        // Add config member
+        CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig config_;
     };
 
     /**
@@ -379,11 +380,8 @@ namespace CryptoShield::Detection {
      */
     class BehavioralDetector {
     public:
-        /**
-         * @brief Constructor
-         */
-        BehavioralDetector();
-
+        // Modify constructor
+        explicit BehavioralDetector(const CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig& config);
         /**
          * @brief Destructor
          */
@@ -483,7 +481,8 @@ namespace CryptoShield::Detection {
         mutable std::atomic<size_t> suspicious_patterns_detected_;
 
         // Configuration
-        MassFileModificationDetector::Configuration config_;
+        // MassFileModificationDetector::Configuration config_; // This line is replaced
+        CryptoShield::Detection::DetectionEngineConfig::BehavioralConfig config_; // New config storage
     };
 
 } // namespace CryptoShield::Detection

--- a/Service/CryptoShieldService/Detection/DetectionConfig.cpp
+++ b/Service/CryptoShieldService/Detection/DetectionConfig.cpp
@@ -110,6 +110,14 @@ namespace CryptoShield::Detection {
                         );
                     }
                 }
+                if (b.contains("suspicious_patterns_regex") && b["suspicious_patterns_regex"].is_array()) {
+                    current_config_.behavioral.suspicious_patterns_regex.clear();
+                    for (const auto& pat : b["suspicious_patterns_regex"]) {
+                        current_config_.behavioral.suspicious_patterns_regex.push_back(
+                            std::wstring(pat.get<std::string>().begin(), pat.get<std::string>().end())
+                        );
+                    }
+                }
             }
 
             // Parse system activity configuration
@@ -172,6 +180,47 @@ namespace CryptoShield::Detection {
                 current_config_.false_positive.reputation_history_days = fp.value("reputation_history_days", 30);
                 current_config_.false_positive.auto_whitelist_signed = fp.value("auto_whitelist_signed", false);
                 current_config_.false_positive.strict_mode = fp.value("strict_mode", false);
+
+                if (fp.contains("trusted_publishers") && fp["trusted_publishers"].is_array()) {
+                    current_config_.false_positive.trusted_publishers.clear();
+                    for (const auto& pub : fp["trusted_publishers"]) {
+                        current_config_.false_positive.trusted_publishers.push_back(
+                            std::wstring(pub.get<std::string>().begin(), pub.get<std::string>().end())
+                        );
+                    }
+                }
+                if (fp.contains("trusted_backup_software") && fp["trusted_backup_software"].is_array()) {
+                    current_config_.false_positive.trusted_backup_software.clear();
+                    for (const auto& proc : fp["trusted_backup_software"]) {
+                        current_config_.false_positive.trusted_backup_software.push_back(
+                            std::wstring(proc.get<std::string>().begin(), proc.get<std::string>().end())
+                        );
+                    }
+                }
+                if (fp.contains("trusted_compression_software") && fp["trusted_compression_software"].is_array()) {
+                    current_config_.false_positive.trusted_compression_software.clear();
+                    for (const auto& proc : fp["trusted_compression_software"]) {
+                        current_config_.false_positive.trusted_compression_software.push_back(
+                            std::wstring(proc.get<std::string>().begin(), proc.get<std::string>().end())
+                        );
+                    }
+                }
+                if (fp.contains("trusted_dev_software") && fp["trusted_dev_software"].is_array()) {
+                    current_config_.false_positive.trusted_dev_software.clear();
+                    for (const auto& proc : fp["trusted_dev_software"]) {
+                        current_config_.false_positive.trusted_dev_software.push_back(
+                            std::wstring(proc.get<std::string>().begin(), proc.get<std::string>().end())
+                        );
+                    }
+                }
+                if (fp.contains("trusted_system_software") && fp["trusted_system_software"].is_array()) {
+                    current_config_.false_positive.trusted_system_software.clear();
+                    for (const auto& proc : fp["trusted_system_software"]) {
+                        current_config_.false_positive.trusted_system_software.push_back(
+                            std::wstring(proc.get<std::string>().begin(), proc.get<std::string>().end())
+                        );
+                    }
+                }
             }
 
             // Parse response configuration
@@ -291,9 +340,15 @@ namespace CryptoShield::Detection {
 
             // Save suspicious extensions
             auto& exts = j["behavioral_detection"]["suspicious_extensions"];
+            exts = nlohmann::json::array(); // Initialize as array
             for (const auto& ext : current_config_.behavioral.suspicious_extensions) {
                 //exts.push_back(std::string(ext.begin(), ext.end()));
                 exts.push_back(ext);
+            }
+            auto& patterns_regex = j["behavioral_detection"]["suspicious_patterns_regex"];
+            patterns_regex = nlohmann::json::array(); // Initialize as array
+            for (const auto& pat : current_config_.behavioral.suspicious_patterns_regex) {
+                patterns_regex.push_back(std::string(pat.begin(), pat.end()));
             }
 
             // Save system monitoring configuration
@@ -350,6 +405,32 @@ namespace CryptoShield::Detection {
             j["false_positive_minimizer"]["reputation_history_days"] = current_config_.false_positive.reputation_history_days;
             j["false_positive_minimizer"]["auto_whitelist_signed"] = current_config_.false_positive.auto_whitelist_signed;
             j["false_positive_minimizer"]["strict_mode"] = current_config_.false_positive.strict_mode;
+
+            auto& trusted_pubs = j["false_positive_minimizer"]["trusted_publishers"];
+            trusted_pubs = nlohmann::json::array(); // Initialize as array
+            for (const auto& pub : current_config_.false_positive.trusted_publishers) {
+                trusted_pubs.push_back(std::string(pub.begin(), pub.end()));
+            }
+            auto& backup_sw = j["false_positive_minimizer"]["trusted_backup_software"];
+            backup_sw = nlohmann::json::array(); // Initialize as array
+            for (const auto& proc : current_config_.false_positive.trusted_backup_software) {
+                backup_sw.push_back(std::string(proc.begin(), proc.end()));
+            }
+            auto& comp_sw = j["false_positive_minimizer"]["trusted_compression_software"];
+            comp_sw = nlohmann::json::array(); // Initialize as array
+            for (const auto& proc : current_config_.false_positive.trusted_compression_software) {
+                comp_sw.push_back(std::string(proc.begin(), proc.end()));
+            }
+            auto& dev_sw = j["false_positive_minimizer"]["trusted_dev_software"];
+            dev_sw = nlohmann::json::array(); // Initialize as array
+            for (const auto& proc : current_config_.false_positive.trusted_dev_software) {
+                dev_sw.push_back(std::string(proc.begin(), proc.end()));
+            }
+            auto& sys_sw = j["false_positive_minimizer"]["trusted_system_software"];
+            sys_sw = nlohmann::json::array(); // Initialize as array
+            for (const auto& proc : current_config_.false_positive.trusted_system_software) {
+                sys_sw.push_back(std::string(proc.begin(), proc.end()));
+            }
 
             // Save response configuration
             j["response"]["enable_auto_response"] = current_config_.response.enable_auto_response;
@@ -518,6 +599,10 @@ namespace CryptoShield::Detection {
             L".locked", L".encrypted", L".crypto", L".enc",
             L".crypted", L".kraken", L".darkness", L".nochance"
         };
+        config.behavioral.suspicious_patterns_regex = {
+            L".*\\.id-[0-9A-F]{8}\\.[a-z]+@[a-z]+\\.[a-z]+$",
+            L".*\\.[0-9A-F]{32}$"
+        };
 
         // System activity configuration
         config.system_activity.enabled = true;
@@ -567,6 +652,11 @@ namespace CryptoShield::Detection {
         config.false_positive.reputation_history_days = 30;
         config.false_positive.auto_whitelist_signed = false;
         config.false_positive.strict_mode = false;
+        config.false_positive.trusted_publishers = { L"Microsoft Corporation", L"Google LLC" };
+        config.false_positive.trusted_backup_software = { L"Acronis", L"Veeam", L"Macrium" };
+        config.false_positive.trusted_compression_software = { L"WinRAR", L"7-Zip", L"WinZip" };
+        config.false_positive.trusted_dev_software = { L"devenv", L"cl.exe", L"gcc" };
+        config.false_positive.trusted_system_software = { L"TrustedInstaller", L"svchost" };
 
         // Response configuration
         config.response.enable_auto_response = true;

--- a/Service/CryptoShieldService/Detection/DetectionConfig.cpp
+++ b/Service/CryptoShieldService/Detection/DetectionConfig.cpp
@@ -14,6 +14,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <nlohmann/json.hpp>
+#include "../Utils/StringUtils.h"
 
 namespace CryptoShield::Detection {
 
@@ -281,6 +282,7 @@ namespace CryptoShield::Detection {
         }
     }
 
+
     /**
      * @brief Save configuration to file
      */
@@ -343,12 +345,12 @@ namespace CryptoShield::Detection {
             exts = nlohmann::json::array(); // Initialize as array
             for (const auto& ext : current_config_.behavioral.suspicious_extensions) {
                 //exts.push_back(std::string(ext.begin(), ext.end()));
-                exts.push_back(ext);
+                exts.push_back(CryptoShield::Utils::to_string_utf8(ext));
             }
             auto& patterns_regex = j["behavioral_detection"]["suspicious_patterns_regex"];
             patterns_regex = nlohmann::json::array(); // Initialize as array
             for (const auto& pat : current_config_.behavioral.suspicious_patterns_regex) {
-                patterns_regex.push_back(std::string(pat.begin(), pat.end()));
+                patterns_regex.push_back(CryptoShield::Utils::to_string_utf8(pat));
             }
 
             // Save system monitoring configuration
@@ -409,27 +411,27 @@ namespace CryptoShield::Detection {
             auto& trusted_pubs = j["false_positive_minimizer"]["trusted_publishers"];
             trusted_pubs = nlohmann::json::array(); // Initialize as array
             for (const auto& pub : current_config_.false_positive.trusted_publishers) {
-                trusted_pubs.push_back(std::string(pub.begin(), pub.end()));
+                trusted_pubs.push_back(CryptoShield::Utils::to_string_utf8(pub));
             }
             auto& backup_sw = j["false_positive_minimizer"]["trusted_backup_software"];
             backup_sw = nlohmann::json::array(); // Initialize as array
             for (const auto& proc : current_config_.false_positive.trusted_backup_software) {
-                backup_sw.push_back(std::string(proc.begin(), proc.end()));
+                backup_sw.push_back(CryptoShield::Utils::to_string_utf8(proc));
             }
             auto& comp_sw = j["false_positive_minimizer"]["trusted_compression_software"];
             comp_sw = nlohmann::json::array(); // Initialize as array
             for (const auto& proc : current_config_.false_positive.trusted_compression_software) {
-                comp_sw.push_back(std::string(proc.begin(), proc.end()));
+                comp_sw.push_back(CryptoShield::Utils::to_string_utf8(proc));
             }
             auto& dev_sw = j["false_positive_minimizer"]["trusted_dev_software"];
             dev_sw = nlohmann::json::array(); // Initialize as array
             for (const auto& proc : current_config_.false_positive.trusted_dev_software) {
-                dev_sw.push_back(std::string(proc.begin(), proc.end()));
+                dev_sw.push_back(CryptoShield::Utils::to_string_utf8(proc));
             }
             auto& sys_sw = j["false_positive_minimizer"]["trusted_system_software"];
             sys_sw = nlohmann::json::array(); // Initialize as array
             for (const auto& proc : current_config_.false_positive.trusted_system_software) {
-                sys_sw.push_back(std::string(proc.begin(), proc.end()));
+                sys_sw.push_back(CryptoShield::Utils::to_string_utf8(proc));
             }
 
             // Save response configuration

--- a/Service/CryptoShieldService/Detection/DetectionConfig.h
+++ b/Service/CryptoShieldService/Detection/DetectionConfig.h
@@ -97,6 +97,7 @@ namespace CryptoShield::Detection {
             bool track_temporal_patterns;
             std::vector<std::wstring> suspicious_extensions;
             double suspicion_score_threshold;
+            std::vector<std::wstring> suspicious_patterns_regex;
         } behavioral;
 
         // System activity monitoring configuration
@@ -160,6 +161,11 @@ namespace CryptoShield::Detection {
             bool strict_mode;
             std::wstring whitelist_file;
             std::wstring reputation_database;
+            std::vector<std::wstring> trusted_publishers;
+            std::vector<std::wstring> trusted_backup_software;
+            std::vector<std::wstring> trusted_compression_software;
+            std::vector<std::wstring> trusted_dev_software;
+            std::vector<std::wstring> trusted_system_software;
         } false_positive;
 
         // Response configuration

--- a/Service/CryptoShieldService/Detection/DetectionConfig.h
+++ b/Service/CryptoShieldService/Detection/DetectionConfig.h
@@ -21,473 +21,474 @@
 
 namespace CryptoShield::Detection {
 
-    /**
-     * @brief Configuration validation result
-     */
-    struct ConfigValidationResult {
-        bool is_valid;
-        std::vector<std::wstring> errors;
-        std::vector<std::wstring> warnings;
-        std::map<std::wstring, std::wstring> suggestions;
-    };
+	/**
+	 * @brief Configuration validation result
+	 */
+	struct ConfigValidationResult {
+		bool is_valid;
+		std::vector<std::wstring> errors;
+		std::vector<std::wstring> warnings;
+		std::map<std::wstring, std::wstring> suggestions;
+	};
 
-    /**
-     * @brief Configuration change event
-     */
-    struct ConfigChangeEvent {
-        std::wstring component_name;
-        std::wstring parameter_name;
-        std::wstring old_value;
-        std::wstring new_value;
-        std::chrono::system_clock::time_point timestamp;
-        std::wstring changed_by;
-    };
+	/**
+	 * @brief Configuration change event
+	 */
+	struct ConfigChangeEvent {
+		std::wstring component_name;
+		std::wstring parameter_name;
+		std::wstring old_value;
+		std::wstring new_value;
+		std::chrono::system_clock::time_point timestamp;
+		std::wstring changed_by;
+	};
 
-    /**
-     * @brief Master configuration structure
-     * @details Contains all configuration parameters for the detection engine
-     */
-    struct DetectionEngineConfig {
-        // Engine metadata
-        std::wstring config_version;
-        std::chrono::system_clock::time_point last_modified;
-        std::wstring modified_by;
+	/**
+	 * @brief Master configuration structure
+	 * @details Contains all configuration parameters for the detection engine
+	 */
+	struct DetectionEngineConfig {
+		// Engine metadata
+		std::wstring config_version;
+		std::chrono::system_clock::time_point last_modified;
+		std::wstring modified_by;
 
-        // Global settings
-        struct GlobalSettings {
-            bool enable_detection;
-            bool enable_logging;
-            bool enable_telemetry;
-            bool debug_mode;
-            std::wstring log_directory;
-            size_t max_log_size_mb;
-            size_t log_retention_days;
-            size_t thread_pool_size;
-            size_t max_memory_usage_mb;
-        } global;
+		// Global settings
+		struct GlobalSettings {
+			bool enable_detection;
+			bool enable_logging;
+			bool enable_telemetry;
+			bool debug_mode;
+			std::wstring log_directory;
+			size_t max_log_size_mb;
+			size_t log_retention_days;
+			size_t thread_pool_size;
+			size_t max_memory_usage_mb;
+		} global;
 
-        // Entropy analysis configuration
-        struct EntropyConfig {
-            bool enabled;
-            double weight;
-            double threshold_text_files;
-            double threshold_images;
-            double threshold_executables;
-            double threshold_compressed;
-            double threshold_databases;
-            double threshold_unknown;
-            size_t block_size;
-            bool enable_chi_square;
-            bool enable_hamming_distance;
-            bool enable_advanced_analysis;
-            size_t max_file_size_for_analysis;
-        } entropy;
+		// Entropy analysis configuration
+		struct EntropyConfig {
+			bool enabled;
+			double weight;
+			double threshold_text_files;
+			double threshold_images;
+			double threshold_executables;
+			double threshold_compressed;
+			double threshold_databases;
+			double threshold_unknown;
+			size_t block_size;
+			bool enable_chi_square;
+			bool enable_hamming_distance;
+			bool enable_advanced_analysis;
+			size_t max_file_size_for_analysis;
+		} entropy;
 
-        // Behavioral detection configuration
-        struct BehavioralConfig {
-            bool enabled;
-            double weight;
-            size_t min_operations_threshold;
-            size_t min_directories_threshold;
-            size_t min_extensions_threshold;
-            double max_operations_per_second;
-            size_t time_window_seconds;
-            bool track_extension_changes;
-            bool track_directory_traversal;
-            bool track_temporal_patterns;
-            std::vector<std::wstring> suspicious_extensions;
-            double suspicion_score_threshold;
-            std::vector<std::wstring> suspicious_patterns_regex;
-        } behavioral;
+		// Behavioral detection configuration
+		struct BehavioralConfig {
+			bool enabled;
+			double weight;
+			size_t min_operations_threshold;
+			size_t min_directories_threshold;
+			size_t min_extensions_threshold;
+			double max_operations_per_second;
+			size_t time_window_seconds;
+			bool track_extension_changes;
+			bool track_directory_traversal;
+			bool track_temporal_patterns;
+			std::vector<std::wstring> suspicious_extensions;
+			double suspicion_score_threshold;
+			std::vector<std::wstring> suspicious_patterns_regex;
+			std::chrono::seconds window_duration;
+		} behavioral;
 
-        // System activity monitoring configuration
-        struct SystemActivityConfig {
-            bool enabled;
-            double weight;
-            bool monitor_shadow_copy_deletion;
-            bool monitor_registry_changes;
-            bool monitor_boot_configuration;
-            bool monitor_security_software;
-            bool monitor_network_activity;
-            size_t command_line_history_size;
-            size_t registry_history_size;
-            std::vector<std::wstring> critical_registry_keys;
-            std::vector<std::wstring> suspicious_commands;
-        } system_activity;
+		// System activity monitoring configuration
+		struct SystemActivityConfig {
+			bool enabled;
+			double weight;
+			bool monitor_shadow_copy_deletion;
+			bool monitor_registry_changes;
+			bool monitor_boot_configuration;
+			bool monitor_security_software;
+			bool monitor_network_activity;
+			size_t command_line_history_size;
+			size_t registry_history_size;
+			std::vector<std::wstring> critical_registry_keys;
+			std::vector<std::wstring> suspicious_commands;
+		} system_activity;
 
-        // Scoring engine configuration
-        struct ScoringConfig {
-            double entropy_weight;
-            double behavioral_weight;
-            double system_activity_weight;
-            double temporal_weight;
-            double threshold_low;
-            double threshold_medium;
-            double threshold_high;
-            double threshold_critical;
-            bool enable_false_positive_reduction;
-            double false_positive_weight;
-            bool enable_detailed_explanation;
-            bool enable_confidence_boosting;
-            double confidence_boost_threshold;
-        } scoring;
+		// Scoring engine configuration
+		struct ScoringConfig {
+			double entropy_weight;
+			double behavioral_weight;
+			double system_activity_weight;
+			double temporal_weight;
+			double threshold_low;
+			double threshold_medium;
+			double threshold_high;
+			double threshold_critical;
+			bool enable_false_positive_reduction;
+			double false_positive_weight;
+			bool enable_detailed_explanation;
+			bool enable_confidence_boosting;
+			double confidence_boost_threshold;
+		} scoring;
 
-        // Pattern database configuration
-        struct PatternDatabaseConfig {
-            bool enabled;
-            std::wstring database_file;
-            bool auto_update;
-            size_t update_interval_hours;
-            std::wstring update_server;
-            bool enable_custom_patterns;
-            std::wstring custom_patterns_file;
-            size_t max_patterns;
-            double min_pattern_confidence;
-            bool enable_fuzzy_matching;
-            double fuzzy_match_threshold;
-        } pattern_database;
+		// Pattern database configuration
+		struct PatternDatabaseConfig {
+			bool enabled;
+			std::wstring database_file;
+			bool auto_update;
+			size_t update_interval_hours;
+			std::wstring update_server;
+			bool enable_custom_patterns;
+			std::wstring custom_patterns_file;
+			size_t max_patterns;
+			double min_pattern_confidence;
+			bool enable_fuzzy_matching;
+			double fuzzy_match_threshold;
+		} pattern_database;
 
-        // False positive minimizer configuration
-        struct FalsePositiveConfig {
-            bool enabled;
-            bool enable_whitelist;
-            bool enable_reputation_system;
-            bool enable_signature_verification;
-            bool enable_behavioral_analysis;
-            double min_reputation_score;
-            double max_fp_adjustment;
-            size_t reputation_history_days;
-            bool auto_whitelist_signed;
-            bool strict_mode;
-            std::wstring whitelist_file;
-            std::wstring reputation_database;
-            std::vector<std::wstring> trusted_publishers;
-            std::vector<std::wstring> trusted_backup_software;
-            std::vector<std::wstring> trusted_compression_software;
-            std::vector<std::wstring> trusted_dev_software;
-            std::vector<std::wstring> trusted_system_software;
-        } false_positive;
+		// False positive minimizer configuration
+		struct FalsePositiveConfig {
+			bool enabled;
+			bool enable_whitelist;
+			bool enable_reputation_system;
+			bool enable_signature_verification;
+			bool enable_behavioral_analysis;
+			double min_reputation_score;
+			double max_fp_adjustment;
+			size_t reputation_history_days;
+			bool auto_whitelist_signed;
+			bool strict_mode;
+			std::wstring whitelist_file;
+			std::wstring reputation_database;
+			std::vector<std::wstring> trusted_publishers;
+			std::vector<std::wstring> trusted_backup_software;
+			std::vector<std::wstring> trusted_compression_software;
+			std::vector<std::wstring> trusted_dev_software;
+			std::vector<std::wstring> trusted_system_software;
+		} false_positive;
 
-        // Response configuration
-        struct ResponseConfig {
-            bool enable_auto_response;
-            bool enable_process_termination;
-            bool enable_file_quarantine;
-            bool enable_network_isolation;
-            bool enable_alerts;
-            bool enable_logging_only_mode;
-            size_t response_delay_ms;
-            std::vector<std::wstring> alert_recipients;
-            std::wstring quarantine_directory;
-        } response;
+		// Response configuration
+		struct ResponseConfig {
+			bool enable_auto_response;
+			bool enable_process_termination;
+			bool enable_file_quarantine;
+			bool enable_network_isolation;
+			bool enable_alerts;
+			bool enable_logging_only_mode;
+			size_t response_delay_ms;
+			std::vector<std::wstring> alert_recipients;
+			std::wstring quarantine_directory;
+		} response;
 
-        // Performance tuning
-        struct PerformanceConfig {
-            size_t max_concurrent_analyses;
-            size_t analysis_timeout_ms;
-            size_t cache_size_mb;
-            bool enable_gpu_acceleration;
-            bool enable_simd_optimization;
-            size_t batch_processing_size;
-            double cpu_usage_limit_percent;
-            bool enable_adaptive_performance;
-        } performance;
-    };
+		// Performance tuning
+		struct PerformanceConfig {
+			size_t max_concurrent_analyses;
+			size_t analysis_timeout_ms;
+			size_t cache_size_mb;
+			bool enable_gpu_acceleration;
+			bool enable_simd_optimization;
+			size_t batch_processing_size;
+			double cpu_usage_limit_percent;
+			bool enable_adaptive_performance;
+		} performance;
+	};
 
-    /**
-     * @brief Configuration manager class
-     * @details Handles loading, saving, validation, and management of configurations
-     */
-    class DetectionConfigManager {
-    public:
-        /**
-         * @brief Constructor
-         */
-        DetectionConfigManager();
+	/**
+	 * @brief Configuration manager class
+	 * @details Handles loading, saving, validation, and management of configurations
+	 */
+	class DetectionConfigManager {
+	public:
+		/**
+		 * @brief Constructor
+		 */
+		DetectionConfigManager();
 
-        /**
-         * @brief Destructor
-         */
-        ~DetectionConfigManager();
+		/**
+		 * @brief Destructor
+		 */
+		~DetectionConfigManager();
 
-        // Disable copy
-        DetectionConfigManager(const DetectionConfigManager&) = delete;
-        DetectionConfigManager& operator=(const DetectionConfigManager&) = delete;
+		// Disable copy
+		DetectionConfigManager(const DetectionConfigManager&) = delete;
+		DetectionConfigManager& operator=(const DetectionConfigManager&) = delete;
 
-        /**
-         * @brief Load configuration from file
-         * @param config_file Path to configuration file
-         * @return true on success
-         */
-        bool LoadConfiguration(const std::wstring& config_file);
+		/**
+		 * @brief Load configuration from file
+		 * @param config_file Path to configuration file
+		 * @return true on success
+		 */
+		bool LoadConfiguration(const std::wstring& config_file);
 
-        /**
-         * @brief Save configuration to file
-         * @param config_file Path to save configuration
-         * @return true on success
-         */
-        bool SaveConfiguration(const std::wstring& config_file) const;
+		/**
+		 * @brief Save configuration to file
+		 * @param config_file Path to save configuration
+		 * @return true on success
+		 */
+		bool SaveConfiguration(const std::wstring& config_file) const;
 
-        /**
-         * @brief Get current configuration
-         * @return Current configuration
-         */
-        DetectionEngineConfig GetConfiguration() const;
+		/**
+		 * @brief Get current configuration
+		 * @return Current configuration
+		 */
+		DetectionEngineConfig GetConfiguration() const;
 
-        /**
-         * @brief Update configuration
-         * @param config New configuration
-         * @return Validation result
-         */
-        ConfigValidationResult UpdateConfiguration(const DetectionEngineConfig& config);
+		/**
+		 * @brief Update configuration
+		 * @param config New configuration
+		 * @return Validation result
+		 */
+		ConfigValidationResult UpdateConfiguration(const DetectionEngineConfig& config);
 
-        /**
-         * @brief Validate configuration
-         * @param config Configuration to validate
-         * @return Validation result
-         */
-        ConfigValidationResult ValidateConfiguration(const DetectionEngineConfig& config) const;
+		/**
+		 * @brief Validate configuration
+		 * @param config Configuration to validate
+		 * @return Validation result
+		 */
+		ConfigValidationResult ValidateConfiguration(const DetectionEngineConfig& config) const;
 
-        /**
-         * @brief Get default configuration
-         * @return Default configuration
-         */
-        static DetectionEngineConfig GetDefaultConfiguration();
+		/**
+		 * @brief Get default configuration
+		 * @return Default configuration
+		 */
+		static DetectionEngineConfig GetDefaultConfiguration();
 
-        /**
-         * @brief Reset to default configuration
-         */
-        void ResetToDefaults();
+		/**
+		 * @brief Reset to default configuration
+		 */
+		void ResetToDefaults();
 
-        /**
-         * @brief Merge configurations
-         * @param base Base configuration
-         * @param overlay Configuration to merge
-         * @return Merged configuration
-         */
-        static DetectionEngineConfig MergeConfigurations(
-            const DetectionEngineConfig& base,
-            const DetectionEngineConfig& overlay);
+		/**
+		 * @brief Merge configurations
+		 * @param base Base configuration
+		 * @param overlay Configuration to merge
+		 * @return Merged configuration
+		 */
+		static DetectionEngineConfig MergeConfigurations(
+			const DetectionEngineConfig& base,
+			const DetectionEngineConfig& overlay);
 
-        /**
-         * @brief Export configuration as JSON string
-         * @return JSON representation
-         */
-        std::string ExportAsJson() const;
+		/**
+		 * @brief Export configuration as JSON string
+		 * @return JSON representation
+		 */
+		std::string ExportAsJson() const;
 
-        /**
-         * @brief Import configuration from JSON string
-         * @param json_str JSON string
-         * @return true on success
-         */
-        bool ImportFromJson(const std::string& json_str);
+		/**
+		 * @brief Import configuration from JSON string
+		 * @param json_str JSON string
+		 * @return true on success
+		 */
+		bool ImportFromJson(const std::string& json_str);
 
-        /**
-         * @brief Get configuration parameter
-         * @param path Parameter path (e.g., "entropy.threshold_text_files")
-         * @return Parameter value if found
-         */
-        std::optional<std::wstring> GetParameter(const std::wstring& path) const;
+		/**
+		 * @brief Get configuration parameter
+		 * @param path Parameter path (e.g., "entropy.threshold_text_files")
+		 * @return Parameter value if found
+		 */
+		std::optional<std::wstring> GetParameter(const std::wstring& path) const;
 
-        /**
-         * @brief Set configuration parameter
-         * @param path Parameter path
-         * @param value New value
-         * @return true if parameter was set
-         */
-        bool SetParameter(const std::wstring& path, const std::wstring& value);
+		/**
+		 * @brief Set configuration parameter
+		 * @param path Parameter path
+		 * @param value New value
+		 * @return true if parameter was set
+		 */
+		bool SetParameter(const std::wstring& path, const std::wstring& value);
 
-        /**
-         * @brief Get configuration change history
-         * @param max_entries Maximum entries to return
-         * @return Change history
-         */
-        std::vector<ConfigChangeEvent> GetChangeHistory(size_t max_entries = 100) const;
+		/**
+		 * @brief Get configuration change history
+		 * @param max_entries Maximum entries to return
+		 * @return Change history
+		 */
+		std::vector<ConfigChangeEvent> GetChangeHistory(size_t max_entries = 100) const;
 
-        /**
-         * @brief Register configuration change callback
-         * @param callback Function to call on configuration change
-         */
-        void RegisterChangeCallback(
-            std::function<void(const ConfigChangeEvent&)> callback);
+		/**
+		 * @brief Register configuration change callback
+		 * @param callback Function to call on configuration change
+		 */
+		void RegisterChangeCallback(
+			std::function<void(const ConfigChangeEvent&)> callback);
 
-        /**
-         * @brief Validate configuration file
-         * @param config_file Path to configuration file
-         * @return Validation result
-         */
-        static ConfigValidationResult ValidateConfigurationFile(
-            const std::wstring& config_file);
+		/**
+		 * @brief Validate configuration file
+		 * @param config_file Path to configuration file
+		 * @return Validation result
+		 */
+		static ConfigValidationResult ValidateConfigurationFile(
+			const std::wstring& config_file);
 
-        /**
-         * @brief Create configuration template
-         * @param template_file Path to save template
-         * @param include_comments Include descriptive comments
-         * @return true on success
-         */
-        static bool CreateConfigurationTemplate(const std::wstring& template_file,
-            bool include_comments = true);
+		/**
+		 * @brief Create configuration template
+		 * @param template_file Path to save template
+		 * @param include_comments Include descriptive comments
+		 * @return true on success
+		 */
+		static bool CreateConfigurationTemplate(const std::wstring& template_file,
+			bool include_comments = true);
 
-        /**
-         * @brief Get configuration schema
-         * @return JSON schema for configuration validation
-         */
-        static std::string GetConfigurationSchema();
+		/**
+		 * @brief Get configuration schema
+		 * @return JSON schema for configuration validation
+		 */
+		static std::string GetConfigurationSchema();
 
-        /**
-         * @brief Backup current configuration
-         * @param backup_file Path to backup file
-         * @return true on success
-         */
-        bool BackupConfiguration(const std::wstring& backup_file) const;
+		/**
+		 * @brief Backup current configuration
+		 * @param backup_file Path to backup file
+		 * @return true on success
+		 */
+		bool BackupConfiguration(const std::wstring& backup_file) const;
 
-        /**
-         * @brief Restore configuration from backup
-         * @param backup_file Path to backup file
-         * @return true on success
-         */
-        bool RestoreConfiguration(const std::wstring& backup_file);
+		/**
+		 * @brief Restore configuration from backup
+		 * @param backup_file Path to backup file
+		 * @return true on success
+		 */
+		bool RestoreConfiguration(const std::wstring& backup_file);
 
-        /**
-         * @brief Get configuration statistics
-         */
-        struct ConfigStatistics {
-            size_t total_parameters;
-            size_t enabled_components;
-            size_t disabled_components;
-            std::chrono::system_clock::time_point last_load_time;
-            std::chrono::system_clock::time_point last_save_time;
-            size_t change_count;
-        };
+		/**
+		 * @brief Get configuration statistics
+		 */
+		struct ConfigStatistics {
+			size_t total_parameters;
+			size_t enabled_components;
+			size_t disabled_components;
+			std::chrono::system_clock::time_point last_load_time;
+			std::chrono::system_clock::time_point last_save_time;
+			size_t change_count;
+		};
 
-        ConfigStatistics GetStatistics() const;
+		ConfigStatistics GetStatistics() const;
 
-    private:
-        /**
-         * @brief Validate global settings
-         * @param settings Global settings to validate
-         * @param result Validation result to update
-         */
-        void ValidateGlobalSettings(const DetectionEngineConfig::GlobalSettings& settings,
-            ConfigValidationResult& result) const;
+	private:
+		/**
+		 * @brief Validate global settings
+		 * @param settings Global settings to validate
+		 * @param result Validation result to update
+		 */
+		void ValidateGlobalSettings(const DetectionEngineConfig::GlobalSettings& settings,
+			ConfigValidationResult& result) const;
 
-        /**
-         * @brief Validate entropy configuration
-         * @param config Entropy config to validate
-         * @param result Validation result to update
-         */
-        void ValidateEntropyConfig(const DetectionEngineConfig::EntropyConfig& config,
-            ConfigValidationResult& result) const;
+		/**
+		 * @brief Validate entropy configuration
+		 * @param config Entropy config to validate
+		 * @param result Validation result to update
+		 */
+		void ValidateEntropyConfig(const DetectionEngineConfig::EntropyConfig& config,
+			ConfigValidationResult& result) const;
 
-        /**
-         * @brief Validate behavioral configuration
-         * @param config Behavioral config to validate
-         * @param result Validation result to update
-         */
-        void ValidateBehavioralConfig(const DetectionEngineConfig::BehavioralConfig& config,
-            ConfigValidationResult& result) const;
+		/**
+		 * @brief Validate behavioral configuration
+		 * @param config Behavioral config to validate
+		 * @param result Validation result to update
+		 */
+		void ValidateBehavioralConfig(const DetectionEngineConfig::BehavioralConfig& config,
+			ConfigValidationResult& result) const;
 
-        /**
-         * @brief Validate scoring configuration
-         * @param config Scoring config to validate
-         * @param result Validation result to update
-         */
-        void ValidateScoringConfig(const DetectionEngineConfig::ScoringConfig& config,
-            ConfigValidationResult& result) const;
+		/**
+		 * @brief Validate scoring configuration
+		 * @param config Scoring config to validate
+		 * @param result Validation result to update
+		 */
+		void ValidateScoringConfig(const DetectionEngineConfig::ScoringConfig& config,
+			ConfigValidationResult& result) const;
 
-        /**
-         * @brief Record configuration change
-         * @param component Component name
-         * @param parameter Parameter name
-         * @param old_value Old value
-         * @param new_value New value
-         */
-        void RecordChange(const std::wstring& component,
-            const std::wstring& parameter,
-            const std::wstring& old_value,
-            const std::wstring& new_value);
+		/**
+		 * @brief Record configuration change
+		 * @param component Component name
+		 * @param parameter Parameter name
+		 * @param old_value Old value
+		 * @param new_value New value
+		 */
+		void RecordChange(const std::wstring& component,
+			const std::wstring& parameter,
+			const std::wstring& old_value,
+			const std::wstring& new_value);
 
-        /**
-         * @brief Notify change callbacks
-         * @param event Change event
-         */
-        void NotifyChangeCallbacks(const ConfigChangeEvent& event);
+		/**
+		 * @brief Notify change callbacks
+		 * @param event Change event
+		 */
+		void NotifyChangeCallbacks(const ConfigChangeEvent& event);
 
-        /**
-         * @brief Parse parameter path
-         * @param path Parameter path
-         * @param component Output component name
-         * @param parameter Output parameter name
-         * @return true if path is valid
-         */
-        bool ParseParameterPath(const std::wstring& path,
-            std::wstring& component,
-            std::wstring& parameter) const;
+		/**
+		 * @brief Parse parameter path
+		 * @param path Parameter path
+		 * @param component Output component name
+		 * @param parameter Output parameter name
+		 * @return true if path is valid
+		 */
+		bool ParseParameterPath(const std::wstring& path,
+			std::wstring& component,
+			std::wstring& parameter) const;
 
-    private:
-        // Current configuration
-        mutable std::mutex config_mutex_;
-        DetectionEngineConfig current_config_;
+	private:
+		// Current configuration
+		mutable std::mutex config_mutex_;
+		DetectionEngineConfig current_config_;
 
-        // Change history
-        mutable std::mutex history_mutex_;
-        std::vector<ConfigChangeEvent> change_history_;
+		// Change history
+		mutable std::mutex history_mutex_;
+		std::vector<ConfigChangeEvent> change_history_;
 
-        // Change callbacks
-        mutable std::mutex callbacks_mutex_;
-        std::vector<std::function<void(const ConfigChangeEvent&)>> change_callbacks_;
+		// Change callbacks
+		mutable std::mutex callbacks_mutex_;
+		std::vector<std::function<void(const ConfigChangeEvent&)>> change_callbacks_;
 
-        // Statistics
-        mutable std::mutex stats_mutex_;
-        ConfigStatistics statistics_;
+		// Statistics
+		mutable std::mutex stats_mutex_;
+		ConfigStatistics statistics_;
 
-        // Configuration file paths
-        std::wstring current_config_file_;
-        std::wstring last_backup_file_;
+		// Configuration file paths
+		std::wstring current_config_file_;
+		std::wstring last_backup_file_;
 
-        // Validation state
-        mutable ConfigValidationResult last_validation_result_;
-    };
+		// Validation state
+		mutable ConfigValidationResult last_validation_result_;
+	};
 
-    /**
-     * @brief Configuration utilities
-     */
-    class ConfigurationUtils {
-    public:
-        /**
-         * @brief Convert configuration to command line arguments
-         * @param config Configuration
-         * @return Command line arguments
-         */
-        static std::vector<std::wstring> ConfigToCommandLine(
-            const DetectionEngineConfig& config);
+	/**
+	 * @brief Configuration utilities
+	 */
+	class ConfigurationUtils {
+	public:
+		/**
+		 * @brief Convert configuration to command line arguments
+		 * @param config Configuration
+		 * @return Command line arguments
+		 */
+		static std::vector<std::wstring> ConfigToCommandLine(
+			const DetectionEngineConfig& config);
 
-        /**
-         * @brief Parse command line to configuration overrides
-         * @param argc Argument count
-         * @param argv Argument values
-         * @return Configuration with overrides
-         */
-        static DetectionEngineConfig ParseCommandLine(int argc, wchar_t* argv[]);
+		/**
+		 * @brief Parse command line to configuration overrides
+		 * @param argc Argument count
+		 * @param argv Argument values
+		 * @return Configuration with overrides
+		 */
+		static DetectionEngineConfig ParseCommandLine(int argc, wchar_t* argv[]);
 
-        /**
-         * @brief Generate configuration documentation
-         * @param output_file Path to output file
-         * @param format Documentation format (md, html, txt)
-         * @return true on success
-         */
-        static bool GenerateDocumentation(const std::wstring& output_file,
-            const std::wstring& format = L"md");
+		/**
+		 * @brief Generate configuration documentation
+		 * @param output_file Path to output file
+		 * @param format Documentation format (md, html, txt)
+		 * @return true on success
+		 */
+		static bool GenerateDocumentation(const std::wstring& output_file,
+			const std::wstring& format = L"md");
 
-        /**
-         * @brief Compare configurations
-         * @param config1 First configuration
-         * @param config2 Second configuration
-         * @return List of differences
-         */
-        static std::vector<std::wstring> CompareConfigurations(
-            const DetectionEngineConfig& config1,
-            const DetectionEngineConfig& config2);
-    };
+		/**
+		 * @brief Compare configurations
+		 * @param config1 First configuration
+		 * @param config2 Second configuration
+		 * @return List of differences
+		 */
+		static std::vector<std::wstring> CompareConfigurations(
+			const DetectionEngineConfig& config1,
+			const DetectionEngineConfig& config2);
+	};
 
 } // namespace CryptoShield::Detection

--- a/Service/CryptoShieldService/Detection/FalsePositiveMinimizer.cpp
+++ b/Service/CryptoShieldService/Detection/FalsePositiveMinimizer.cpp
@@ -25,47 +25,12 @@
 namespace CryptoShield::Detection {
 
     // Static member definitions
-    const std::vector<std::wstring> FalsePositiveMinimizer::BACKUP_SOFTWARE = {
-        L"Acronis", L"TrueImage", L"BackupExec", L"Veeam", L"ShadowProtect",
-        L"Macrium", L"EaseUS", L"AOMEI", L"Paragon", L"Cobian",
-        L"FreeFileSync", L"SyncBack", L"GoodSync", L"Duplicati", L"BackBlaze",
-        L"CrashPlan", L"Carbonite", L"IDrive", L"pCloud", L"SpiderOak"
-    };
-
-    const std::vector<std::wstring> FalsePositiveMinimizer::COMPRESSION_SOFTWARE = {
-        L"WinRAR", L"7-Zip", L"7z", L"WinZip", L"PeaZip",
-        L"Bandizip", L"IZArc", L"PowerArchiver", L"ZipGenius", L"FreeArc",
-        L"HaoZip", L"B1Archiver", L"Hamster", L"Express Zip", L"ALZip"
-    };
-
-    const std::vector<std::wstring> FalsePositiveMinimizer::MEDIA_SOFTWARE = {
-        L"HandBrake", L"FFmpeg", L"VLC", L"OBS", L"Adobe Premiere",
-        L"Adobe After Effects", L"DaVinci Resolve", L"Sony Vegas", L"Camtasia",
-        L"Audacity", L"FL Studio", L"Ableton", L"Pro Tools", L"Media Encoder",
-        L"Format Factory", L"Any Video Converter", L"Freemake", L"MKVToolNix"
-    };
-
-    const std::vector<std::wstring> FalsePositiveMinimizer::DEVELOPMENT_SOFTWARE = {
-        L"devenv", L"Visual Studio", L"VSCode", L"Code", L"eclipse",
-        L"IntelliJ", L"PyCharm", L"WebStorm", L"Android Studio", L"Xcode",
-        L"gcc", L"g++", L"clang", L"cl.exe", L"javac",
-        L"python", L"node", L"npm", L"dotnet", L"go",
-        L"rustc", L"cargo", L"gradle", L"maven", L"make"
-    };
-
-    const std::vector<std::wstring> FalsePositiveMinimizer::SYSTEM_SOFTWARE = {
-        L"TrustedInstaller", L"svchost", L"services", L"lsass", L"csrss",
-        L"wininit", L"winlogon", L"explorer", L"taskmgr", L"mmc",
-        L"dism", L"sfc", L"chkdsk", L"defrag", L"cleanmgr",
-        L"SystemSettings", L"UserAccountControlSettings", L"CompMgmtLauncher"
-    };
-
-    const std::vector<std::wstring> FalsePositiveMinimizer::SECURITY_SOFTWARE = {
-        L"MsMpEng", L"Windows Defender", L"MBAMService", L"Malwarebytes",
-        L"avp", L"Kaspersky", L"avgnt", L"Avira", L"mcshield",
-        L"McAfee", L"bdagent", L"Bitdefender", L"NortonSecurity", L"360se",
-        L"ESET", L"nod32", L"Sophos", L"SAVService", L"CylanceSvc"
-    };
+    // const std::vector<std::wstring> FalsePositiveMinimizer::BACKUP_SOFTWARE = { ... }; // DELETE
+    // const std::vector<std::wstring> FalsePositiveMinimizer::COMPRESSION_SOFTWARE = { ... }; // DELETE
+    // const std::vector<std::wstring> FalsePositiveMinimizer::MEDIA_SOFTWARE = { ... }; // DELETE
+    // const std::vector<std::wstring> FalsePositiveMinimizer::DEVELOPMENT_SOFTWARE = { ... }; // DELETE
+    // const std::vector<std::wstring> FalsePositiveMinimizer::SYSTEM_SOFTWARE = { ... }; // DELETE
+    // const std::vector<std::wstring> FalsePositiveMinimizer::SECURITY_SOFTWARE = { ... }; // DELETE
 
     const std::map<SoftwareCategory, std::vector<std::wstring>>
         FalsePositiveMinimizer::LEGITIMATE_EXTENSIONS = {
@@ -91,27 +56,16 @@ namespace CryptoShield::Detection {
             }}
     };
 
-    const std::vector<std::wstring> FalsePositiveMinimizer::TRUSTED_PUBLISHERS = {
-        L"Microsoft Corporation", L"Microsoft Windows",
-        L"Adobe Inc.", L"Adobe Systems Incorporated",
-        L"Google LLC", L"Google Inc",
-        L"Mozilla Corporation", L"Apple Inc.",
-        L"Oracle Corporation", L"Intel Corporation",
-        L"NVIDIA Corporation", L"AMD Inc.",
-        L"Symantec Corporation", L"McAfee, Inc.",
-        L"Kaspersky Lab", L"Bitdefender SRL",
-        L"ESET, spol. s r.o.", L"Avast Software s.r.o.",
-        L"Malwarebytes Inc.", L"Sophos Ltd."
-    };
+    // const std::vector<std::wstring> FalsePositiveMinimizer::TRUSTED_PUBLISHERS = { ... }; // DELETE
 
     /**
      * @brief Constructor
      */
-    FalsePositiveMinimizer::FalsePositiveMinimizer(
-        const FalsePositiveMinimizerConfig& config)
-        : config_(config)
-        , statistics_{}
-    {
+    FalsePositiveMinimizer::FalsePositiveMinimizer(const CryptoShield::Detection::DetectionEngineConfig::FalsePositiveConfig& config)
+        : config_(config), // Initialize the member
+          statistics_{} {
+        // Existing constructor body, like Initialize()
+        // Initialize(); // Will be called after construction by TraditionalEngine typically
     }
 
     /**
@@ -149,7 +103,7 @@ namespace CryptoShield::Detection {
         std::lock_guard<std::mutex> lock(processes_mutex_);
 
         // Backup software
-        for (const auto& name : BACKUP_SOFTWARE) {
+        for (const auto& name : config_.trusted_backup_software) { // Use config list
             LegitimateProcess proc;
             proc.process_name = name;
             proc.category = SoftwareCategory::BACKUP_SOFTWARE;
@@ -168,7 +122,7 @@ namespace CryptoShield::Detection {
         }
 
         // Compression tools
-        for (const auto& name : COMPRESSION_SOFTWARE) {
+        for (const auto& name : config_.trusted_compression_software) { // Use config list
             LegitimateProcess proc;
             proc.process_name = name;
             proc.category = SoftwareCategory::COMPRESSION_TOOLS;
@@ -186,27 +140,13 @@ namespace CryptoShield::Detection {
             legitimate_processes_[name] = proc;
         }
 
-        // Media software
-        for (const auto& name : MEDIA_SOFTWARE) {
-            LegitimateProcess proc;
-            proc.process_name = name;
-            proc.category = SoftwareCategory::MEDIA_ENCODERS;
-            proc.trust_score = 0.8;
-            proc.requires_signature = false;
-            proc.allowed_extensions = LEGITIMATE_EXTENSIONS.at(SoftwareCategory::MEDIA_ENCODERS);
-            proc.typical_behaviors = {
-                L"MEDIA_FILE_ACCESS",
-                L"HIGH_CPU_USAGE",
-                L"TEMP_FILE_CREATION",
-                L"SEQUENTIAL_WRITE"
-            };
-            proc.last_updated = std::chrono::system_clock::now();
-
-            legitimate_processes_[name] = proc;
-        }
+        // Media software (Removed as MEDIA_SOFTWARE list is removed)
+        // for (const auto& name : MEDIA_SOFTWARE) {
+        // ...
+        // }
 
         // Development tools
-        for (const auto& name : DEVELOPMENT_SOFTWARE) {
+        for (const auto& name : config_.trusted_dev_software) { // Use config list
             LegitimateProcess proc;
             proc.process_name = name;
             proc.category = SoftwareCategory::DEVELOPMENT_TOOLS;
@@ -225,7 +165,7 @@ namespace CryptoShield::Detection {
         }
 
         // System software - highest trust
-        for (const auto& name : SYSTEM_SOFTWARE) {
+        for (const auto& name : config_.trusted_system_software) { // Use config list
             LegitimateProcess proc;
             proc.process_name = name;
             proc.category = SoftwareCategory::SYSTEM_UTILITIES;
@@ -403,8 +343,8 @@ namespace CryptoShield::Detection {
                 );
 
                 // Check if trusted publisher
-                if (std::find(TRUSTED_PUBLISHERS.begin(), TRUSTED_PUBLISHERS.end(),
-                    signer_name) != TRUSTED_PUBLISHERS.end()) {
+                if (std::find(config_.trusted_publishers.begin(), config_.trusted_publishers.end(), // Use config list
+                    signer_name) != config_.trusted_publishers.end()) {
                     analysis.legitimacy_indicators.push_back(L"Trusted publisher");
                     analysis.false_positive_probability += 0.4;
                 }
@@ -604,11 +544,10 @@ namespace CryptoShield::Detection {
         std::wstring lower_name = process_name;
         std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::towlower);
 
-        for (const auto& tool : COMPRESSION_SOFTWARE) {
-            std::wstring lower_tool = tool;
-            std::transform(lower_tool.begin(), lower_tool.end(), lower_tool.begin(), ::towlower);
-
-            if (lower_name.find(lower_tool) != std::wstring::npos) {
+        for (const auto& tool_pattern : config_.trusted_compression_software) { // Use config list
+            std::wstring lower_tool_pattern = tool_pattern;
+            std::transform(lower_tool_pattern.begin(), lower_tool_pattern.end(), lower_tool_pattern.begin(), ::towlower);
+            if (lower_name.find(lower_tool_pattern) != std::wstring::npos) {
                 is_known_tool = true;
                 break;
             }
@@ -659,19 +598,36 @@ namespace CryptoShield::Detection {
         std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::towlower);
 
         // Check each category
-        for (const auto& backup : BACKUP_SOFTWARE) {
-            std::wstring lower_backup = backup;
-            std::transform(lower_backup.begin(), lower_backup.end(), lower_backup.begin(), ::towlower);
-            if (lower_name.find(lower_backup) != std::wstring::npos) {
+        for (const auto& backup_name_pattern : config_.trusted_backup_software) { // Use config list
+            std::wstring lower_backup_pattern = backup_name_pattern;
+            std::transform(lower_backup_pattern.begin(), lower_backup_pattern.end(), lower_backup_pattern.begin(), ::towlower);
+            if (lower_name.find(lower_backup_pattern) != std::wstring::npos) {
                 return SoftwareCategory::BACKUP_SOFTWARE;
             }
         }
 
-        for (const auto& compress : COMPRESSION_SOFTWARE) {
-            std::wstring lower_compress = compress;
-            std::transform(lower_compress.begin(), lower_compress.end(), lower_compress.begin(), ::towlower);
-            if (lower_name.find(lower_compress) != std::wstring::npos) {
+        for (const auto& compress_name_pattern : config_.trusted_compression_software) { // Use config list
+            std::wstring lower_compress_pattern = compress_name_pattern;
+            std::transform(lower_compress_pattern.begin(), lower_compress_pattern.end(), lower_compress_pattern.begin(), ::towlower);
+            if (lower_name.find(lower_compress_pattern) != std::wstring::npos) {
                 return SoftwareCategory::COMPRESSION_TOOLS;
+            }
+        }
+        // MEDIA_SOFTWARE and SECURITY_SOFTWARE checks would be removed or adapted if they were here
+        // For DEVELOPMENT_SOFTWARE
+        for (const auto& dev_name_pattern : config_.trusted_dev_software) { // Use config list
+            std::wstring lower_dev_pattern = dev_name_pattern;
+            std::transform(lower_dev_pattern.begin(), lower_dev_pattern.end(), lower_dev_pattern.begin(), ::towlower);
+            if (lower_name.find(lower_dev_pattern) != std::wstring::npos) {
+                return SoftwareCategory::DEVELOPMENT_TOOLS;
+            }
+        }
+        // For SYSTEM_SOFTWARE
+        for (const auto& system_name_pattern : config_.trusted_system_software) { // Use config list
+            std::wstring lower_system_pattern = system_name_pattern;
+            std::transform(lower_system_pattern.begin(), lower_system_pattern.end(), lower_system_pattern.begin(), ::towlower);
+            if (lower_name.find(lower_system_pattern) != std::wstring::npos) {
+                return SoftwareCategory::SYSTEM_UTILITIES;
             }
         }
 
@@ -1014,10 +970,10 @@ namespace CryptoShield::Detection {
         std::wstring lower_name = process_name;
         std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::towlower);
 
-        for (const auto& tool : DEVELOPMENT_SOFTWARE) {
-            std::wstring lower_tool = tool;
-            std::transform(lower_tool.begin(), lower_tool.end(), lower_tool.begin(), ::towlower);
-            if (lower_name.find(lower_tool) != std::wstring::npos) {
+        for (const auto& tool_pattern : config_.trusted_dev_software) { // Use config list
+            std::wstring lower_tool_pattern = tool_pattern;
+            std::transform(lower_tool_pattern.begin(), lower_tool_pattern.end(), lower_tool_pattern.begin(), ::towlower);
+            if (lower_name.find(lower_tool_pattern) != std::wstring::npos) {
                 is_dev_tool = true;
                 break;
             }

--- a/Service/CryptoShieldService/Detection/FalsePositiveMinimizer.cpp
+++ b/Service/CryptoShieldService/Detection/FalsePositiveMinimizer.cpp
@@ -767,7 +767,7 @@ namespace CryptoShield::Detection {
     /**
      * @brief Get default configuration
      */
-    FalsePositiveMinimizerConfig FalsePositiveMinimizer::GetDefaultConfig()
+    /*FalsePositiveMinimizerConfig FalsePositiveMinimizer::GetDefaultConfig()
     {
         FalsePositiveMinimizerConfig config;
 
@@ -782,7 +782,7 @@ namespace CryptoShield::Detection {
         config.strict_mode = false;
 
         return config;
-    }
+    }*/
 
     /**
      * @brief Check suspicious anomalies (simplified implementation)

--- a/Service/CryptoShieldService/Detection/FalsePositiveMinimizer.h
+++ b/Service/CryptoShieldService/Detection/FalsePositiveMinimizer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "TraditionalEngine.h"
+#include "DetectionConfig.h" // Added
 #include <windows.h>
 #include <string>
 #include <vector>
@@ -118,17 +119,17 @@ namespace CryptoShield::Detection {
     /**
      * @brief False positive minimizer configuration
      */
-    struct FalsePositiveMinimizerConfig {
-        bool enable_whitelist;
-        bool enable_reputation_system;
+    // struct FalsePositiveMinimizerConfig { // Original struct, will be replaced by DetectionEngineConfig::FalsePositiveConfig
+    //     bool enable_whitelist;
+    //     bool enable_reputation_system;
         bool enable_signature_verification;
         bool enable_behavioral_analysis;
         double min_reputation_score;
         double max_fp_adjustment;
         size_t reputation_history_days;
-        bool auto_whitelist_signed;
-        bool strict_mode;
-    };
+    //     bool auto_whitelist_signed;
+    //     bool strict_mode;
+    // }; // Original struct end
 
     /**
      * @brief Main false positive minimizer class
@@ -136,13 +137,8 @@ namespace CryptoShield::Detection {
      */
     class FalsePositiveMinimizer {
     public:
-        /**
-         * @brief Constructor
-         * @param config Configuration settings
-         */
-        explicit FalsePositiveMinimizer(
-            const FalsePositiveMinimizerConfig& config = GetDefaultConfig());
-
+        // Modify constructor
+        explicit FalsePositiveMinimizer(const CryptoShield::Detection::DetectionEngineConfig::FalsePositiveConfig& config);
         /**
          * @brief Destructor
          */
@@ -298,17 +294,8 @@ namespace CryptoShield::Detection {
 
         Statistics GetStatistics() const;
 
-        /**
-         * @brief Get default configuration
-         * @return Default config
-         */
-        static FalsePositiveMinimizerConfig GetDefaultConfig();
-
-        /**
-         * @brief Update configuration
-         * @param config New configuration
-         */
-        void UpdateConfiguration(const FalsePositiveMinimizerConfig& config);
+        // static FalsePositiveMinimizerConfig GetDefaultConfig(); // Potentially obsolete
+        // void UpdateConfiguration(const FalsePositiveMinimizerConfig& config); // Potentially obsolete or needs signature change
 
     private:
         /**
@@ -384,7 +371,8 @@ namespace CryptoShield::Detection {
 
     private:
         // Configuration
-        FalsePositiveMinimizerConfig config_;
+        // FalsePositiveMinimizerConfig config_; // Old config storage
+        CryptoShield::Detection::DetectionEngineConfig::FalsePositiveConfig config_; // New config storage
 
         // Legitimate process database
         mutable std::mutex processes_mutex_;

--- a/Service/CryptoShieldService/Detection/ScoringEngine.cpp
+++ b/Service/CryptoShieldService/Detection/ScoringEngine.cpp
@@ -16,6 +16,7 @@
 #include "EntropyAnalyzer.h"
 #include "BehavioralDetector.h"
 #include "SystemActivityMonitor.h"
+#include "../Utils/StringUtils.h"
 
 namespace CryptoShield::Detection {
 
@@ -397,6 +398,7 @@ namespace CryptoShield::Detection {
         return score;
     }
 
+    
     /**
      * @brief Calculate behavioral component score
      */
@@ -412,7 +414,7 @@ namespace CryptoShield::Detection {
 
         // Add indicators
         for (const auto& pattern : result.suspicious_patterns) {
-            score.indicators.push_back(std::string(pattern.begin(), pattern.end()));
+            score.indicators.push_back(CryptoShield::Utils::to_string_utf8(pattern));
         }
 
         // Boost score for multiple suspicious patterns
@@ -860,7 +862,8 @@ namespace CryptoShield::Detection {
         // Convert contributing factors to searchable strings
         std::string combined_factors;
         for (const auto& factor : analysis.contributing_factors) {
-            combined_factors += std::string(factor.begin(), factor.end()) + " ";
+            //combined_factors += std::string(factor.begin(), factor.end()) + " ";
+            combined_factors += CryptoShield::Utils::to_string_utf8(factor) + " ";
         }
 
         // Convert to lowercase for matching

--- a/Service/CryptoShieldService/Detection/TraditionalEngine.h
+++ b/Service/CryptoShieldService/Detection/TraditionalEngine.h
@@ -8,7 +8,7 @@
  */
 
 #pragma once
-
+#include "DetectionConfig.h"
 #include <windows.h>
 #include <memory>
 #include <vector>
@@ -82,26 +82,26 @@ namespace CryptoShield::Detection {
     /**
      * @brief Engine configuration
      */
-    struct EngineConfig {
-        // Entropy analysis settings
-        bool enable_entropy_analysis;
-        double entropy_weight;
+    //struct EngineConfig {
+    //    // Entropy analysis settings
+    //    bool enable_entropy_analysis;
+    //    double entropy_weight;
 
-        // Behavioral detection settings
-        bool enable_behavioral_detection;
-        double behavioral_weight;
-        size_t min_operations_for_detection;
+    //    // Behavioral detection settings
+    //    bool enable_behavioral_detection;
+    //    double behavioral_weight;
+    //    size_t min_operations_for_detection;
 
-        // System monitoring settings
-        bool enable_system_monitoring;
-        double system_activity_weight;
+    //    // System monitoring settings
+    //    bool enable_system_monitoring;
+    //    double system_activity_weight;
 
-        // General settings
-        size_t max_file_size_for_analysis;
-        size_t analysis_thread_count;
-        bool enable_false_positive_reduction;
-        bool enable_detailed_logging;
-    };
+    //    // General settings
+    //    size_t max_file_size_for_analysis;
+    //    size_t analysis_thread_count;
+    //    bool enable_false_positive_reduction;
+    //    bool enable_detailed_logging;
+    //};
 
 
     // Añade esta nueva estructura, puede estar fuera o dentro de la clase TraditionalEngine
@@ -122,7 +122,7 @@ namespace CryptoShield::Detection {
          * @brief Constructor
          * @param config Engine configuration
          */
-        explicit TraditionalEngine(const EngineConfig& config = GetDefaultConfig());
+        explicit TraditionalEngine(const DetectionEngineConfig& config);
 
         /**
          * @brief Destructor
@@ -162,7 +162,7 @@ namespace CryptoShield::Detection {
          * @brief Update engine configuration
          * @param config New configuration
          */
-        void UpdateConfiguration(const EngineConfig& config);
+        void UpdateConfiguration(const DetectionEngineConfig& config);
 
         /**
          * @brief Get current engine statistics
@@ -183,14 +183,14 @@ namespace CryptoShield::Detection {
          * @brief Get default engine configuration
          * @return Default configuration
          */
-        static EngineConfig GetDefaultConfig();
+        /*static EngineConfig GetDefaultConfig();*/
 
         /**
          * @brief Load configuration from file
          * @param config_file Path to configuration file
          * @return Loaded configuration
          */
-        static EngineConfig LoadConfiguration(const std::wstring& config_file);
+        /*static DetectionEngineConfig LoadConfiguration(const std::wstring& config_file);*/
 
     private:
         /**
@@ -250,7 +250,7 @@ namespace CryptoShield::Detection {
 
     private:
         // Configuration
-        EngineConfig config_;
+        DetectionEngineConfig config_;
 
         // Detection components
         std::unique_ptr<AdvancedEntropyAnalysis> entropy_analyzer_;

--- a/Service/CryptoShieldService/Main.cpp
+++ b/Service/CryptoShieldService/Main.cpp
@@ -110,6 +110,23 @@ int wmain(int argc, wchar_t* argv[])
             ServiceWorkerThread(nullptr);
             return 0;
         }
+        else if (command == L"/generate-config") {
+            std::wcout << L"Generating default configuration file (detection_config.json)..." << std::endl;
+
+            // Creamos una instancia del gestor de configuración
+            auto config_manager = std::make_unique<CryptoShield::Detection::DetectionConfigManager>();
+
+            // La configuración por defecto ya se carga en el constructor del manager.
+            // Ahora, simplemente la guardamos a un fichero.
+            if (config_manager->SaveConfiguration(L"detection_config.json")) {
+                std::wcout << L"Default configuration file 'detection_config.json' created successfully." << std::endl;
+                return 0;
+            }
+            else {
+                std::wcerr << L"Failed to create default configuration file." << std::endl;
+                return 1;
+            }
+        }
         else {
             std::wcerr << L"Unknown command: " << command << std::endl;
             std::wcerr << L"Usage: " << argv[0] << L" [/install | /uninstall | /start | /stop | /debug]" << std::endl;

--- a/Service/CryptoShieldService/Utils/StringUtils.cpp
+++ b/Service/CryptoShieldService/Utils/StringUtils.cpp
@@ -1,0 +1,34 @@
+#include "StringUtils.h"
+#include <windows.h>
+#include <locale>
+#include <codecvt>
+
+namespace CryptoShield::Utils {
+
+    std::string to_string_utf8(const std::wstring& wstr)
+    {
+        if (wstr.empty()) {
+            return std::string();
+        }
+        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+        std::string strTo(size_needed, 0);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+        return strTo;
+    }
+
+    //std::wstring to_wstring_utf8(const std::string& str)
+    //{
+    //    // std::wstring_convert está deprecado en C++17 pero es muy conveniente.
+    //    // Si tu compilador lo soporta y no tienes restricciones, es una opción fácil.
+    //    // Si no, se puede usar MultiByteToWideChar, que es la contraparte de la otra función.
+    //    try {
+    //        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    //        return converter.from_bytes(str);
+    //    }
+    //    catch (const std::range_error&) {
+    //        // Manejar un posible error si la conversión falla.
+    //        return L"";
+    //    }
+    //}
+
+} // namespace CryptoShield::Utils

--- a/Service/CryptoShieldService/Utils/StringUtils.h
+++ b/Service/CryptoShieldService/Utils/StringUtils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+namespace CryptoShield::Utils {
+
+    /**
+     * @brief Converts a wide string (wstring) to a UTF-8 encoded string.
+     * @param wstr The wide string to convert.
+     * @return The UTF-8 encoded string.
+     */
+    std::string to_string_utf8(const std::wstring& wstr);
+
+    ///**
+    // * @brief Converts a UTF-8 encoded string to a wide string (wstring).
+    // * @param str The UTF-8 encoded string to convert.
+    // * @return The wide string.
+    // */
+    //std::wstring to_wstring_utf8(const std::string& str);
+
+} // namespace CryptoShield::Utils

--- a/Service/CryptoShieldService/detection_config.json
+++ b/Service/CryptoShieldService/detection_config.json
@@ -1,0 +1,193 @@
+{
+    "behavioral_detection": {
+        "enabled": true,
+        "max_ops_per_second": 10.0,
+        "min_directories": 3,
+        "min_extensions": 2,
+        "min_operations": 50,
+        "suspicion_score_threshold": 0.7,
+        "suspicious_extensions": [
+            ".locked",
+            ".encrypted",
+            ".crypto",
+            ".enc",
+            ".crypted",
+            ".kraken",
+            ".darkness",
+            ".nochance"
+        ],
+        "suspicious_patterns_regex": [
+            ".*\\.id-[0-9A-F]{8}\\.[a-z]+@[a-z]+\\.[a-z]+$",
+            ".*\\.[0-9A-F]{32}$"
+        ],
+        "time_window_seconds": 60,
+        "track_directory_traversal": true,
+        "track_extension_changes": true,
+        "track_temporal_patterns": true,
+        "weight": 0.25
+    },
+    "entropy_analysis": {
+        "block_size": 4096,
+        "enable_advanced_analysis": true,
+        "enable_chi_square": true,
+        "enable_hamming_distance": true,
+        "enabled": true,
+        "max_file_size_for_analysis": 104857600,
+        "threshold_compressed": 7.8,
+        "threshold_databases": 5.5,
+        "threshold_executables": 6.0,
+        "threshold_images": 7.0,
+        "threshold_text_files": 4.5,
+        "threshold_unknown": 6.5,
+        "weight": 0.3
+    },
+    "false_positive_minimizer": {
+        "auto_whitelist_signed": false,
+        "enable_behavioral_analysis": true,
+        "enable_reputation": true,
+        "enable_signature_verification": true,
+        "enable_whitelist": true,
+        "enabled": true,
+        "max_fp_adjustment": 0.8,
+        "min_reputation_score": 0.6,
+        "reputation_history_days": 30,
+        "strict_mode": false,
+        "trusted_backup_software": [
+            "Acronis",
+            "Veeam",
+            "Macrium"
+        ],
+        "trusted_compression_software": [
+            "WinRAR",
+            "7-Zip",
+            "WinZip"
+        ],
+        "trusted_dev_software": [
+            "devenv",
+            "cl.exe",
+            "gcc"
+        ],
+        "trusted_publishers": [
+            "Microsoft Corporation",
+            "Google LLC"
+        ],
+        "trusted_system_software": [
+            "TrustedInstaller",
+            "svchost"
+        ]
+    },
+    "global": {
+        "debug_mode": false,
+        "enable_detection": true,
+        "enable_logging": true,
+        "enable_telemetry": false,
+        "log_directory": [
+            67,
+            58,
+            92,
+            80,
+            114,
+            111,
+            103,
+            114,
+            97,
+            109,
+            68,
+            97,
+            116,
+            97,
+            92,
+            67,
+            114,
+            121,
+            112,
+            116,
+            111,
+            83,
+            104,
+            105,
+            101,
+            108,
+            100,
+            92,
+            76,
+            111,
+            103,
+            115
+        ],
+        "log_retention_days": 30,
+        "max_log_size_mb": 100,
+        "max_memory_usage_mb": 200,
+        "thread_pool_size": 4
+    },
+    "pattern_database": {
+        "auto_update": false,
+        "database_file": [
+            112,
+            97,
+            116,
+            116,
+            101,
+            114,
+            110,
+            115,
+            46,
+            100,
+            98
+        ],
+        "enable_custom_patterns": true,
+        "enable_fuzzy_matching": true,
+        "enabled": true,
+        "fuzzy_match_threshold": 0.8,
+        "max_patterns": 10000,
+        "min_pattern_confidence": 0.5,
+        "update_interval_hours": 24
+    },
+    "performance": {
+        "analysis_timeout_ms": 5000,
+        "batch_processing_size": 100,
+        "cache_size_mb": 50,
+        "cpu_usage_limit_percent": 50.0,
+        "enable_adaptive_performance": true,
+        "enable_gpu_acceleration": false,
+        "enable_simd_optimization": true,
+        "max_concurrent_analyses": 10
+    },
+    "response": {
+        "enable_alerts": true,
+        "enable_auto_response": true,
+        "enable_file_quarantine": true,
+        "enable_network_isolation": false,
+        "enable_process_termination": true,
+        "logging_only_mode": false,
+        "response_delay_ms": 1000
+    },
+    "scoring": {
+        "behavioral_weight": 0.25,
+        "confidence_boost_threshold": 0.8,
+        "enable_confidence_boosting": true,
+        "enable_detailed_explanation": true,
+        "enable_fp_reduction": true,
+        "entropy_weight": 0.3,
+        "false_positive_weight": 0.15,
+        "system_activity_weight": 0.25,
+        "temporal_weight": 0.2,
+        "threshold_critical": 0.95,
+        "threshold_high": 0.8,
+        "threshold_low": 0.3,
+        "threshold_medium": 0.6
+    },
+    "system_monitoring": {
+        "command_history_size": 1000,
+        "enabled": true,
+        "monitor_boot_config": true,
+        "monitor_network": false,
+        "monitor_registry": true,
+        "monitor_security_software": true,
+        "monitor_shadow_copy": true,
+        "registry_history_size": 5000,
+        "weight": 0.25
+    },
+    "timestamp": 17493684529099654,
+    "version": "1.0"
+}


### PR DESCRIPTION
- I extended the DetectionConfig.h structures (BehavioralConfig, FalsePositiveConfig) to hold new pattern lists.
- I updated DetectionConfig.cpp to manage default values, loading, and saving of these new lists from/to detection_config.json.
- I refactored BehavioralDetector to accept BehavioralConfig, removing hardcoded suspicious extensions and regex patterns, now sourced from config.
- I refactored FalsePositiveMinimizer to accept FalsePositiveConfig, removing hardcoded lists of trusted publishers and software, now sourced from config.
- I updated TraditionalEngine to use the unified DetectionEngineConfig, passing specific configurations to BehavioralDetector and FalsePositiveMinimizer.
- I modified Main.cpp to use DetectionConfigManager to load settings from detection_config.json and initialize TraditionalEngine with this configuration.

This change allows for dynamic updates to detection patterns and trusted software lists via JSON configuration without recompiling the service.